### PR TITLE
Feature/socket write from file

### DIFF
--- a/ios/TcpSockets.m
+++ b/ios/TcpSockets.m
@@ -115,9 +115,7 @@ RCT_EXPORT_METHOD(write:(nonnull NSNumber*)cId
     
     NSString* base64String = [[[writableString dataUsingEncoding:NSUTF8StringEncoding] base64EncodedStringWithOptions:0] stringByAppendingString:terminationChar];
 
-    // iOS7+
-    // TODO: use https://github.com/nicklockwood/Base64 for compatibility with earlier iOS versions
-    NSData *data = [[NSData alloc] initWithBase64EncodedString:base64String options:NSDataBase64DecodingIgnoreUnknownCharacters];
+    NSData *data = [base64String dataUsingEncoding:NSUTF8StringEncoding];
     [client writeData:data callback:callback];
 }
 

--- a/ios/TcpSockets.m
+++ b/ios/TcpSockets.m
@@ -105,7 +105,7 @@ RCT_EXPORT_METHOD(write:(nonnull NSNumber*)cId
     if (!client) return;
     
     NSFileManager *fileManager = [NSFileManager defaultManager];
-    if (![fileManager fileExistsAtPath:pathForFile]) return;
+    if (![fileManager fileExistsAtPath:path]) return;
     
     NSStringEncoding encoding;
     NSError* error = nil;

--- a/ios/TcpSockets.m
+++ b/ios/TcpSockets.m
@@ -107,15 +107,10 @@ RCT_EXPORT_METHOD(write:(nonnull NSNumber*)cId
     NSFileManager *fileManager = [NSFileManager defaultManager];
     if (![fileManager fileExistsAtPath:path]) return;
     
-    NSStringEncoding encoding;
-    NSError* error = nil;
-    NSString* writableString = [NSString stringWithContentsOfFile:path usedEncoding:&encoding error:&error];
-    
-    if (error != nil) return;
-    
-    NSString* writable = [[[writableString dataUsingEncoding:NSUTF8StringEncoding] base64EncodedStringWithOptions:0] stringByAppendingString:terminationChar];
-
+    NSData *fileData = [[NSData dataWithContentsOfFile:path]base64EncodedDataWithOptions:0];
+    NSString *writable = [[[NSString alloc] initWithData:fileData encoding:NSUTF8StringEncoding] stringByAppendingString:terminationChar];
     NSData *data = [writable dataUsingEncoding:NSUTF8StringEncoding];
+    
     [client writeData:data callback:callback];
 }
 

--- a/ios/TcpSockets.m
+++ b/ios/TcpSockets.m
@@ -113,7 +113,7 @@ RCT_EXPORT_METHOD(write:(nonnull NSNumber*)cId
     
     if (error != nil) return;
     
-    NSString* base64String = [[[writableString stringByAppendingString:terminationChar] dataUsingEncoding:NSUTF8StringEncoding] base64EncodedStringWithOptions:0];
+    NSString* base64String = [[[writableString dataUsingEncoding:NSUTF8StringEncoding] base64EncodedStringWithOptions:0] stringByAppendingString:terminationChar];
 
     // iOS7+
     // TODO: use https://github.com/nicklockwood/Base64 for compatibility with earlier iOS versions

--- a/ios/TcpSockets.m
+++ b/ios/TcpSockets.m
@@ -113,9 +113,9 @@ RCT_EXPORT_METHOD(write:(nonnull NSNumber*)cId
     
     if (error != nil) return;
     
-    NSString* base64String = [[[writableString dataUsingEncoding:NSUTF8StringEncoding] base64EncodedStringWithOptions:0] stringByAppendingString:terminationChar];
+    NSString* writable = [[[writableString dataUsingEncoding:NSUTF8StringEncoding] base64EncodedStringWithOptions:0] stringByAppendingString:terminationChar];
 
-    NSData *data = [base64String dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *data = [writable dataUsingEncoding:NSUTF8StringEncoding];
     [client writeData:data callback:callback];
 }
 

--- a/ios/TcpSockets.m
+++ b/ios/TcpSockets.m
@@ -97,6 +97,30 @@ RCT_EXPORT_METHOD(write:(nonnull NSNumber*)cId
     [client writeData:data callback:callback];
 }
 
+RCT_EXPORT_METHOD(write:(nonnull NSNumber*)cId
+                  filePath:(NSString *)path
+                  terminationCharacter:(NSString*)terminationChar
+                  callback:(RCTResponseSenderBlock)callback) {
+    TcpSocketClient* client = [self findClient:cId];
+    if (!client) return;
+    
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    if (![fileManager fileExistsAtPath:pathForFile]) return;
+    
+    NSStringEncoding encoding;
+    NSError* error = nil;
+    NSString* writableString = [NSString stringWithContentsOfFile:path usedEncoding:&encoding error:&error];
+    
+    if (error != nil) return;
+    
+    NSString* base64String = [writableString stringByAppendingString:terminationChar];
+
+    // iOS7+
+    // TODO: use https://github.com/nicklockwood/Base64 for compatibility with earlier iOS versions
+    NSData *data = [[NSData alloc] initWithBase64EncodedString:base64String options:0];
+    [client writeData:data callback:callback];
+}
+
 RCT_EXPORT_METHOD(end:(nonnull NSNumber*)cId) {
     [self endClient:cId];
 }

--- a/ios/TcpSockets.m
+++ b/ios/TcpSockets.m
@@ -117,7 +117,7 @@ RCT_EXPORT_METHOD(write:(nonnull NSNumber*)cId
 
     // iOS7+
     // TODO: use https://github.com/nicklockwood/Base64 for compatibility with earlier iOS versions
-    NSData *data = [[NSData alloc] initWithBase64EncodedString:base64String options:0];
+    NSData *data = [[NSData alloc] initWithBase64EncodedString:base64String options:NSDataBase64DecodingIgnoreUnknownCharacters];
     [client writeData:data callback:callback];
 }
 

--- a/ios/TcpSockets.m
+++ b/ios/TcpSockets.m
@@ -113,7 +113,7 @@ RCT_EXPORT_METHOD(write:(nonnull NSNumber*)cId
     
     if (error != nil) return;
     
-    NSString* base64String = [writableString stringByAppendingString:terminationChar];
+    NSString* base64String = [[[writableString stringByAppendingString:terminationChar] dataUsingEncoding:NSUTF8StringEncoding] base64EncodedStringWithOptions:0];
 
     // iOS7+
     // TODO: use https://github.com/nicklockwood/Base64 for compatibility with earlier iOS versions


### PR DESCRIPTION
New method to enable socket writing from a filepath.

RCT_EXPORT_METHOD(write:(nonnull NSNumber*)cId
                  filePath:(NSString *)path
                  terminationCharacter:(NSString*)terminationChar
                  callback:(RCTResponseSenderBlock)callback)

1. filepath is read.
2. termination character is appended.
3. result is base64 encoded
4. result is sent to the socket as a write.